### PR TITLE
fix: prevent error when run-bakery is called without any arguments

### DIFF
--- a/bakery/run-bakery
+++ b/bakery/run-bakery
@@ -27,7 +27,7 @@ if [ -n "${RUGIX_CACHE_VOLUME}" ]; then
     DOCKER_FLAGS="${DOCKER_FLAGS} -v ${RUGIX_CACHE_VOLUME}:/var/rugix-bakery/cache"
 fi
 
-if [ "$1" == "run" ]; then
+if [ "${1:-}" == "run" ]; then
     # Add port forwarding for SSH when running a system in a VM.
     DOCKER_FLAGS="${DOCKER_FLAGS} -p 127.0.0.1:2222:2222 -p [::1]:2222:2222"
 fi

--- a/tests/run-bakery
+++ b/tests/run-bakery
@@ -27,7 +27,7 @@ if [ -n "${RUGIX_CACHE_VOLUME}" ]; then
     DOCKER_FLAGS="${DOCKER_FLAGS} -v ${RUGIX_CACHE_VOLUME}:/var/rugix-bakery/cache"
 fi
 
-if [ "$1" == "run" ]; then
+if [ "${1:-}" == "run" ]; then
     # Add port forwarding for SSH when running a system in a VM.
     DOCKER_FLAGS="${DOCKER_FLAGS} -p 127.0.0.1:2222:2222 -p [::1]:2222:2222"
 fi


### PR DESCRIPTION
Due to the usage of the shell option `u`, calling the `run-bakery` script without any arguments causes an error due to referencing `$1`:

```
./run-bakery            
bash: warning: setlocale: LC_ALL: cannot change locale (C.UTF-8): No such file or directory
./run-bakery: line 31: $1: unbound variable
```

By specifying a defualt value via `${1:-}`, it avoids the unbound variable issue.