### PR TITLE
docs: add required system key

### DIFF
--- a/www/docs/bakery/advanced/integration-testing.mdx
+++ b/www/docs/bakery/advanced/integration-testing.mdx
@@ -21,6 +21,7 @@ Test workflows are placed in the `tests` directory of your Rugix Bakery project.
 
 ```toml
 [[systems]]
+system = "<system-name>"
 disk-image = "<image-name>"
 disk-size = "40G"
 ssh = { private-key = "<path-to-private-key>" }


### PR DESCRIPTION
Add missing `system` key to the integration test setup otherwise the following error occurs when trying to run the tests:

```
Error: unable to parse configuration file
├╴at crates/tools/rugix-bakery/src/config.rs:118:29
├╴loading configuration from "/project/tests/basic.toml"
│   
╰─▶ TOML parse error at line 1, column 1
      |
    1 | [[systems]]
      | ^^^^^^^^^^^
    missing field `system`
```