### PR TITLE
docs: use correct commit stage

### DIFF
--- a/www/docs/ctrl/hooks.md
+++ b/www/docs/ctrl/hooks.md
@@ -8,11 +8,11 @@ _Hooks_ provide a powerful mechanism to inject custom behavior at various stages
 
 Hooks are scripts that are executed at specific points in the execution of an operation. For instance, you can run custom scripts after an update is installed (but before the system is rebooted) or before it is committed. Hooks are organized based on the type of the operation and the point in time, referred to as _stage_, when they run. In addition, each hook has a _rank_, specifying the order in which hooks run. You can use hooks to customize and extend various parts of Rugix Ctrl based on your needs and requirements.
 
-Hooks are placed in `/etc/rugix/hooks`. Each operation gets its own directory, for instance, `/etc/rugix/hooks/bootstrap` contains [bootstrapping hooks](#bootstrapping-hooks) and `/etc/rugix/hooks/system-commit` contains [system commit hooks](#system-update-hooks). Each directory gets a subdirectory for each stage of the respective operation. For instance, `system-commit` has a `prepare` stage. The hooks of this stage will run before performing the commit. To add a hook to the respective stage, a file with the name `<rank>-<name>` is placed in the stage directory. Here, `<rank>` is an integer and hooks with a lower rank run earlier than those with a higher rank.
+Hooks are placed in `/etc/rugix/hooks`. Each operation gets its own directory, for instance, `/etc/rugix/hooks/bootstrap` contains [bootstrapping hooks](#bootstrapping-hooks) and `/etc/rugix/hooks/system-commit` contains [system commit hooks](#system-update-hooks). Each directory gets a subdirectory for each stage of the respective operation. For instance, `system-commit` has a `pre-commit` stage. The hooks of this stage will run before performing the commit. To add a hook to the respective stage, a file with the name `<rank>-<name>` is placed in the stage directory. Here, `<rank>` is an integer and hooks with a lower rank run earlier than those with a higher rank.
 
 For instance, you may add the following file to add a check before committing to an update:
 
-```bash title="/etc/rugix/hooks/system-commit/prepare/10-check_system_health.sh"
+```bash title="/etc/rugix/hooks/system-commit/pre-commit/10-check_system_health.sh"
 #!/bin/bash
 
 # Function to check whether a service is active.

--- a/www/versioned_docs/version-0.8.5/ctrl/hooks.md
+++ b/www/versioned_docs/version-0.8.5/ctrl/hooks.md
@@ -8,11 +8,11 @@ _Hooks_ provide a powerful mechanism to inject custom behavior at various stages
 
 Hooks are scripts that are executed at specific points in the execution of an operation. For instance, you can run custom scripts after an update is installed (but before the system is rebooted) or before it is committed. Hooks are organized based on the type of the operation and the point in time, referred to as _stage_, when they run. In addition, each hook has a _rank_, specifying the order in which hooks run. You can use hooks to customize and extend various parts of Rugix Ctrl based on your needs and requirements.
 
-Hooks are placed in `/etc/rugix/hooks`. Each operation gets its own directory, for instance, `/etc/rugix/hooks/bootstrap` contains [bootstrapping hooks](#bootstrapping-hooks) and `/etc/rugix/hooks/system-commit` contains [system commit hooks](#system-update-hooks). Each directory gets a subdirectory for each stage of the respective operation. For instance, `system-commit` has a `prepare` stage. The hooks of this stage will run before performing the commit. To add a hook to the respective stage, a file with the name `<rank>-<name>` is placed in the stage directory. Here, `<rank>` is an integer and hooks with a lower rank run earlier than those with a higher rank.
+Hooks are placed in `/etc/rugix/hooks`. Each operation gets its own directory, for instance, `/etc/rugix/hooks/bootstrap` contains [bootstrapping hooks](#bootstrapping-hooks) and `/etc/rugix/hooks/system-commit` contains [system commit hooks](#system-update-hooks). Each directory gets a subdirectory for each stage of the respective operation. For instance, `system-commit` has a `pre-commit` stage. The hooks of this stage will run before performing the commit. To add a hook to the respective stage, a file with the name `<rank>-<name>` is placed in the stage directory. Here, `<rank>` is an integer and hooks with a lower rank run earlier than those with a higher rank.
 
 For instance, you may add the following file to add a check before committing to an update:
 
-```bash title="/etc/rugix/hooks/system-commit/prepare/10-check_system_health.sh"
+```bash title="/etc/rugix/hooks/system-commit/pre-commit/10-check_system_health.sh"
 #!/bin/bash
 
 # Function to check whether a service is active.


### PR DESCRIPTION
In the documentation it says one of the `commit`-stages are `prepare`, when it in reality is `pre-commit`. Updated the documentation so it doesn't confuse the reader.