### PR TITLE
ctrl: run post-reset hook after reset

### DIFF
--- a/crates/tools/rugix-ctrl/src/init.rs
+++ b/crates/tools/rugix-ctrl/src/init.rs
@@ -170,7 +170,7 @@ fn init() -> SystemResult<()> {
         // The existence of the file indicates that the state shall be reset.
         fs::remove_dir_all(state_profile).ok();
         reset_hooks
-            .run_hooks("pre-reset", Vars::new(), &Default::default())
+            .run_hooks("post-reset", Vars::new(), &Default::default())
             .whatever("unable to run `post-reset` hooks")?;
     }
     fs::create_dir_all(state_profile).ok();


### PR DESCRIPTION
Commit 5dd3716 ("implement hooks as now documented") implements hooking into resetting the state directory, but calls the "pre-reset" hook both before and after resetting. Call the "post-reset" hook after resetting instead.

Fixes: 5dd3716 ("implement hooks as now documented")