### PR TITLE
disk: print start of partition on next_free check

### DIFF
--- a/crates/libs/rugix-common/src/disk/mod.rs
+++ b/crates/libs/rugix-common/src/disk/mod.rs
@@ -159,7 +159,7 @@ impl PartitionTable {
             if partition.start < next_free {
                 bail!(
                     "invalid starting block of partition ({} < {next_free})",
-                    next_free
+                    partition.start
                 )
             }
             if partition.number < next_number {


### PR DESCRIPTION
If a partition starts too early an error occurs and a message is logged that should show where the partition starts and where it is allowed to start. Previously the log message showed the next allowed block for both values. Change this to show where the partition starts and where it is allowed to start.

Fixes: c8902e2 ("chore: polish image partition table computation")