### PR TITLE
rugix-admin API - system update installs from URL

### DIFF
--- a/crates/apps/rugix-admin/frontend/src/App.tsx
+++ b/crates/apps/rugix-admin/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   AdminApi,
+  installSystemUpdateFromUrl,
   type InstallOptions,
   subscribeJob,
   uploadAppBundle,
@@ -151,6 +152,18 @@ export function App() {
     }
   }
 
+  async function installSystemUrl(url: string, options: InstallOptions) {
+    const jobId = createJobId();
+    setLogs((current) => ({ ...current, [jobId]: { lines: [] } }));
+    watchJob(jobId);
+    try {
+      const job = await installSystemUpdateFromUrl(jobId, url, options);
+      setLogs((current) => ({ ...current, [jobId]: { ...(current[jobId] ?? { lines: [] }), job } }));
+    } catch (error) {
+      setError(errorMessage(error));
+    }
+  }
+
   return (
     <div className="mesh-gradient min-h-screen bg-elevation-0 text-foreground">
       <TopNav
@@ -183,6 +196,7 @@ export function App() {
             system={system}
             onAction={(action) => void runSystemAction(action)}
             onUpload={(file, options) => void upload("system", file, options)}
+            onUrlInstall={(url, options) => void installSystemUrl(url, options)}
           />
         )}
         {tab === "components" && <ComponentsPage report={components} />}

--- a/crates/apps/rugix-admin/frontend/src/api.ts
+++ b/crates/apps/rugix-admin/frontend/src/api.ts
@@ -15,9 +15,10 @@ export class ApiRequestError extends Error {
 }
 
 async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const { headers, ...requestInit } = init ?? {};
   const response = await fetch(url, {
-    headers: { Accept: "application/json", ...(init?.headers ?? {}) },
-    ...init,
+    ...requestInit,
+    headers: { Accept: "application/json", ...(headers ?? {}) },
   });
   if (!response.ok) {
     let message = response.statusText;
@@ -67,6 +68,9 @@ export function subscribeJob(jobId: string, onEvent: (event: events.AdminEvent) 
   source.addEventListener("upload-progress", (message) =>
     onEvent(JSON.parse((message as MessageEvent).data) as events.AdminEvent),
   );
+  source.addEventListener("install-progress", (message) =>
+    onEvent(JSON.parse((message as MessageEvent).data) as events.AdminEvent),
+  );
   return source;
 }
 
@@ -77,6 +81,14 @@ export function uploadSystemUpdate(
   onProgress: (sent: number, total: number) => void,
 ) {
   return uploadBundle(`/api/system/update/${encodeURIComponent(jobId)}${installQuery(options)}`, "image", file, onProgress);
+}
+
+export function installSystemUpdateFromUrl(jobId: string, url: string, options: InstallOptions) {
+  return request<api.JobResponse>(`/api/system/update/${encodeURIComponent(jobId)}/url${installQuery(options)}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url }),
+  }).then((response) => response.job);
 }
 
 export function uploadAppBundle(

--- a/crates/apps/rugix-admin/frontend/src/features/install/UploadPanel.tsx
+++ b/crates/apps/rugix-admin/frontend/src/features/install/UploadPanel.tsx
@@ -1,46 +1,94 @@
-import { ChevronDown, Upload } from "lucide-react";
+import { ChevronDown, Link, Upload } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import type { InstallOptions } from "../../api";
 import { Input } from "../../shared/components/Input";
 import { Surface } from "../../shared/components/Surface";
 import { formatBytes } from "../../shared/lib/format";
-import { fieldClass, primaryButtonClass } from "../../shared/styles";
+import { buttonClass, fieldClass, primaryButtonClass } from "../../shared/styles";
 
 export function UploadPanel({
   title,
   fileLabel,
   icon,
   system,
+  allowUrl,
   onUpload,
+  onUrlInstall,
 }: {
   title: string;
   fileLabel: string;
   icon: ReactNode;
   system?: boolean;
+  allowUrl?: boolean;
   onUpload: (file: File, options: InstallOptions) => void;
+  onUrlInstall?: (url: string, options: InstallOptions) => void;
 }) {
+  const [source, setSource] = useState<"file" | "url">("file");
   const [file, setFile] = useState<File>();
+  const [url, setUrl] = useState("");
   const [bundleHash, setBundleHash] = useState("");
   const [rootCert, setRootCert] = useState("");
   const [insecure, setInsecure] = useState(false);
   const [allowMissingIndex, setAllowMissingIndex] = useState(false);
   const [reboot, setReboot] = useState<InstallOptions["reboot"]>("no");
+  const options = {
+    bundleHash,
+    rootCert,
+    insecureSkipBundleVerification: insecure,
+    insecureAllowMissingBlockIndex: allowMissingIndex,
+    reboot: system ? reboot : undefined,
+  };
+  const canInstall = source === "file" ? !!file : !!url.trim();
 
   return (
     <Surface title={title} icon={icon}>
       <div className="space-y-4">
-        <label className="block">
-          <input className="sr-only" type="file" onChange={(event) => setFile(event.target.files?.[0])} />
-          <span className="flex min-h-24 cursor-pointer items-center justify-between gap-4 rounded-lg border border-dashed border-frame bg-elevation-0 px-4 py-3 transition hover:border-primary hover:bg-primary-muted">
-            <span className="min-w-0">
-              <span className="block text-sm font-medium text-foreground">{file?.name ?? fileLabel}</span>
-              <span className="mt-1 block truncate text-xs text-foreground-muted">{file ? formatBytes(file.size) : "No file selected"}</span>
+        {allowUrl && (
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              className={source === "file" ? primaryButtonClass : buttonClass}
+              onClick={() => setSource("file")}
+            >
+              <Upload size={16} /> File
+            </button>
+            <button
+              type="button"
+              className={source === "url" ? primaryButtonClass : buttonClass}
+              onClick={() => setSource("url")}
+            >
+              <Link size={16} /> URL
+            </button>
+          </div>
+        )}
+
+        {source === "file" ? (
+          <label className="block">
+            <input className="sr-only" type="file" onChange={(event) => setFile(event.target.files?.[0])} />
+            <span className="flex min-h-24 cursor-pointer items-center justify-between gap-4 rounded-lg border border-dashed border-frame bg-elevation-0 px-4 py-3 transition hover:border-primary hover:bg-primary-muted">
+              <span className="min-w-0">
+                <span className="block text-sm font-medium text-foreground">{file?.name ?? fileLabel}</span>
+                <span className="mt-1 block truncate text-xs text-foreground-muted">{file ? formatBytes(file.size) : "No file selected"}</span>
+              </span>
+              <span className="inline-flex h-9 shrink-0 items-center justify-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-content">
+                <Upload size={16} /> Choose
+              </span>
             </span>
-            <span className="inline-flex h-9 shrink-0 items-center justify-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-content">
-              <Upload size={16} /> Choose
+          </label>
+        ) : (
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-foreground-muted">Update URL</span>
+            <span className="flex items-center gap-2">
+              <input
+                className={fieldClass}
+                type="url"
+                value={url}
+                onChange={(event) => setUrl(event.target.value)}
+                placeholder="https://example.com/update.rugixb"
+              />
             </span>
-          </span>
-        </label>
+          </label>
+        )}
 
         <details className="group border-t border-divider pt-3">
           <summary className="flex cursor-pointer list-none items-center justify-between text-sm font-medium text-foreground-muted transition hover:text-foreground">
@@ -79,17 +127,14 @@ export function UploadPanel({
         <div className="flex justify-end">
           <button
             className={primaryButtonClass}
-            disabled={!file}
-            onClick={() =>
-              file &&
-              onUpload(file, {
-                bundleHash,
-                rootCert,
-                insecureSkipBundleVerification: insecure,
-                insecureAllowMissingBlockIndex: allowMissingIndex,
-                reboot: system ? reboot : undefined,
-              })
-            }
+            disabled={!canInstall}
+            onClick={() => {
+              if (source === "file" && file) {
+                onUpload(file, options);
+              } else if (source === "url") {
+                onUrlInstall?.(url.trim(), options);
+              }
+            }}
           >
             <Upload size={16} /> Install
           </button>

--- a/crates/apps/rugix-admin/frontend/src/features/jobs/ActiveOperation.tsx
+++ b/crates/apps/rugix-admin/frontend/src/features/jobs/ActiveOperation.tsx
@@ -3,7 +3,7 @@ import type { jobs } from "../../generated";
 import { Surface } from "../../shared/components/Surface";
 import { ProgressMeter } from "../../shared/components/ProgressMeter";
 import { formatBytes } from "../../shared/lib/format";
-import { uploadProgress } from "../../shared/lib/jobEvents";
+import { jobProgress, progressLabel } from "../../shared/lib/jobEvents";
 import { JobStatusBadge } from "../../shared/status/JobStatusBadge";
 import { buttonClass } from "../../shared/styles";
 import type { JobLog } from "../../types";
@@ -19,7 +19,7 @@ export function ActiveOperation({
   log?: JobLog;
   onOpen: () => void;
 }) {
-  const uploadPercent = uploadProgress(log);
+  const progressPercent = jobProgress(log);
   const latestLine = log?.lines.at(-1);
 
   return (
@@ -33,7 +33,7 @@ export function ActiveOperation({
           </div>
           <div className="mt-1 truncate font-mono text-xs text-foreground-muted">{latestLine ?? jobId}</div>
         </div>
-        <ProgressMeter percent={uploadPercent} fallback={log?.uploadedBytes ? `${formatBytes(Number(log.uploadedBytes))} uploaded` : undefined} />
+        <ProgressMeter label={progressLabel(log)} percent={progressPercent} fallback={log?.uploadedBytes ? `${formatBytes(Number(log.uploadedBytes))} uploaded` : undefined} />
         <button className={buttonClass} onClick={onOpen}>
           <Terminal size={16} /> View Log
         </button>

--- a/crates/apps/rugix-admin/frontend/src/features/jobs/JobLogSurface.tsx
+++ b/crates/apps/rugix-admin/frontend/src/features/jobs/JobLogSurface.tsx
@@ -4,12 +4,12 @@ import { EmptyState } from "../../shared/components/EmptyState";
 import { ProgressMeter } from "../../shared/components/ProgressMeter";
 import { Surface } from "../../shared/components/Surface";
 import { formatBytes } from "../../shared/lib/format";
-import { uploadProgress } from "../../shared/lib/jobEvents";
+import { jobProgress, progressLabel } from "../../shared/lib/jobEvents";
 import { JobStatusBadge } from "../../shared/status/JobStatusBadge";
 import type { JobLog } from "../../types";
 
 export function JobLogSurface({ jobId, job, log }: { jobId?: string; job?: jobs.Job; log?: JobLog }) {
-  const uploadPercent = uploadProgress(log);
+  const progressPercent = jobProgress(log);
   return (
     <Surface title="Job Log" icon={<Terminal size={18} />} action={job && <JobStatusBadge status={job.status} />}>
       {jobId ? (
@@ -18,7 +18,7 @@ export function JobLogSurface({ jobId, job, log }: { jobId?: string; job?: jobs.
             <div className="truncate text-sm font-medium">{job?.title ?? jobId}</div>
             <div className="mt-1 truncate font-mono text-xs text-foreground-muted">{jobId}</div>
           </div>
-          <ProgressMeter percent={uploadPercent} fallback={log?.uploadedBytes ? `${formatBytes(Number(log.uploadedBytes))} uploaded` : undefined} />
+          <ProgressMeter label={progressLabel(log)} percent={progressPercent} fallback={log?.uploadedBytes ? `${formatBytes(Number(log.uploadedBytes))} uploaded` : undefined} />
           <pre className="h-[min(58vh,560px)] overflow-auto rounded-md border border-divider bg-elevation-0 p-3 font-mono text-xs leading-5 text-foreground">
             {(log?.lines.length ? log.lines : ["No output."]).join("\n")}
           </pre>

--- a/crates/apps/rugix-admin/frontend/src/features/system/SystemPage.tsx
+++ b/crates/apps/rugix-admin/frontend/src/features/system/SystemPage.tsx
@@ -12,10 +12,12 @@ export function SystemPage({
   system,
   onAction,
   onUpload,
+  onUrlInstall,
 }: {
   system?: api.SystemInfoResponse;
   onAction: (action: string) => void;
   onUpload: (file: File, options: InstallOptions) => void;
+  onUrlInstall: (url: string, options: InstallOptions) => void;
 }) {
   return (
     <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_420px]">
@@ -28,7 +30,15 @@ export function SystemPage({
           </div>
         </Surface>
 
-        <UploadPanel title="System Update" fileLabel="Update bundle" icon={<Upload size={18} />} system onUpload={onUpload} />
+        <UploadPanel
+          title="System Update"
+          fileLabel="Update bundle"
+          icon={<Upload size={18} />}
+          system
+          allowUrl
+          onUpload={onUpload}
+          onUrlInstall={onUrlInstall}
+        />
       </div>
 
       <Surface title="System Actions">

--- a/crates/apps/rugix-admin/frontend/src/shared/components/ProgressMeter.tsx
+++ b/crates/apps/rugix-admin/frontend/src/shared/components/ProgressMeter.tsx
@@ -1,14 +1,23 @@
-export function ProgressMeter({ percent, fallback }: { percent?: number; fallback?: string }) {
+export function ProgressMeter({
+  label = "Upload",
+  percent,
+  fallback,
+}: {
+  label?: string;
+  percent?: number;
+  fallback?: string;
+}) {
   if (percent === undefined && !fallback) return null;
+  const boundedPercent = percent === undefined ? undefined : Math.min(Math.max(percent, 0), 100);
   return (
     <div>
       <div className="mb-1 flex justify-between text-xs text-foreground-muted">
-        <span>Upload</span>
-        <span>{percent === undefined ? fallback : `${percent}%`}</span>
+        <span>{label}</span>
+        <span>{boundedPercent === undefined ? fallback : `${boundedPercent}%`}</span>
       </div>
-      {percent !== undefined && (
+      {boundedPercent !== undefined && (
         <div className="h-1.5 overflow-hidden rounded-full bg-elevation-3">
-          <div className="h-full bg-primary" style={{ width: `${percent}%` }} />
+          <div className="h-full bg-primary" style={{ width: `${boundedPercent}%` }} />
         </div>
       )}
     </div>

--- a/crates/apps/rugix-admin/frontend/src/shared/lib/jobEvents.ts
+++ b/crates/apps/rugix-admin/frontend/src/shared/lib/jobEvents.ts
@@ -15,8 +15,12 @@ export function applyEvent(current: Record<string, JobLog>, event: events.AdminE
       [event.jobId]: { ...previous, lines: [...previous.lines, `[${event.stream}] ${event.line}`].slice(-500) },
     };
   }
+  if (event.type === "upload-progress") {
+    const previous = current[event.jobId] ?? { lines: [] };
+    return { ...current, [event.jobId]: { ...previous, uploadedBytes: event.bytes } };
+  }
   const previous = current[event.jobId] ?? { lines: [] };
-  return { ...current, [event.jobId]: { ...previous, uploadedBytes: event.bytes } };
+  return { ...current, [event.jobId]: { ...previous, installProgress: event.progress } };
 }
 
 export function updateBrowserProgress(current: Record<string, JobLog>, jobId: string, sent: number, total: number) {
@@ -24,9 +28,14 @@ export function updateBrowserProgress(current: Record<string, JobLog>, jobId: st
   return { ...current, [jobId]: { ...previous, browserUpload: { sent, total } } };
 }
 
-export function uploadProgress(log?: JobLog) {
+export function jobProgress(log?: JobLog) {
+  if (log?.installProgress !== undefined) return Math.round(Number(log.installProgress));
   if (!log?.browserUpload) return undefined;
   return Math.round((log.browserUpload.sent / Math.max(log.browserUpload.total, 1)) * 100);
+}
+
+export function progressLabel(log?: JobLog) {
+  return log?.installProgress === undefined ? "Upload" : "Install";
 }
 
 export function isTerminal(status: jobs.JobStatus) {

--- a/crates/apps/rugix-admin/frontend/src/types.ts
+++ b/crates/apps/rugix-admin/frontend/src/types.ts
@@ -8,5 +8,6 @@ export type JobLog = {
   job?: jobs.Job;
   lines: string[];
   uploadedBytes?: events.UploadProgressEvent["bytes"];
+  installProgress?: events.InstallProgressEvent["progress"];
   browserUpload?: { sent: number; total: number };
 };

--- a/crates/apps/rugix-admin/frontend/tests/conftest.py
+++ b/crates/apps/rugix-admin/frontend/tests/conftest.py
@@ -143,6 +143,18 @@ def wait_for_upload(fake_dir: Path, kind: str, timeout: float = 10) -> dict:
     raise AssertionError(f"timed out waiting for {kind} upload; saw {uploads!r}")
 
 
+def wait_for_command(fake_dir: Path, args: list[str], timeout: float = 10) -> dict:
+    deadline = time.monotonic() + timeout
+    commands: list[dict] = []
+    while time.monotonic() < deadline:
+        commands = read_jsonl(fake_dir / "commands.jsonl")
+        for command in reversed(commands):
+            if command.get("args") == args:
+                return command
+        time.sleep(0.1)
+    raise AssertionError(f"timed out waiting for command {args!r}; saw {commands!r}")
+
+
 def screenshot_path(request: pytest.FixtureRequest, name: str) -> Path:
     safe_name = (
         request.node.nodeid.replace("::", "--")

--- a/crates/apps/rugix-admin/frontend/tests/e2e/test_admin.py
+++ b/crates/apps/rugix-admin/frontend/tests/e2e/test_admin.py
@@ -5,7 +5,7 @@ import hashlib
 import pytest
 from playwright.sync_api import Page, expect
 
-from conftest import AdminServer, read_jsonl, screenshot_path, wait_for_upload
+from conftest import AdminServer, read_jsonl, screenshot_path, wait_for_command, wait_for_upload
 
 
 pytestmark = pytest.mark.e2e
@@ -87,6 +87,47 @@ def test_uploads_system_update_through_browser_and_fake_rugix_ctrl(
     assert any(command["args"] == upload["args"] for command in commands)
 
     page.screenshot(path=str(screenshot_path(request, "system-upload")), full_page=True)
+
+
+def test_installs_system_update_from_url_through_browser_and_fake_rugix_ctrl(
+    page: Page,
+    admin_server: AdminServer,
+    request: pytest.FixtureRequest,
+) -> None:
+    page.goto(admin_server.frontend_url)
+    page.get_by_role("button", name="URL").click()
+    page.get_by_label("Update URL").fill("https://updates.example.com/update.rugixb")
+    page.get_by_text("Advanced").click()
+    page.get_by_label("Bundle hash").fill("url-system-hash")
+    page.get_by_label("Root certificate").fill("/etc/rugix/system-root.pem")
+    page.get_by_label("Reboot").select_option("deferred")
+    page.get_by_label("Skip verification").check()
+    page.get_by_label("Allow missing index").check()
+
+    page.get_by_role("button", name="Install").click()
+
+    expect(page.get_by_text("Install system update")).to_be_visible()
+    expect(page.get_by_text("succeeded").first).to_be_visible()
+    expect(page.get_by_text("100%").first).to_be_visible()
+    expect(page.get_by_text("fake system update install running")).to_be_visible()
+    expect(page.get_by_text('{"event":"UpdateProgress","progress":100.0}')).not_to_be_visible()
+
+    expected_args = [
+        "update",
+        "install",
+        "--insecure-skip-bundle-verification",
+        "--insecure-allow-missing-block-index",
+        "--root-cert",
+        "/etc/rugix/system-root.pem",
+        "--bundle-hash",
+        "url-system-hash",
+        "--reboot",
+        "deferred",
+        "https://updates.example.com/update.rugixb",
+    ]
+    wait_for_command(admin_server.fake_dir, expected_args)
+
+    page.screenshot(path=str(screenshot_path(request, "system-url")), full_page=True)
 
 
 def test_failed_app_upload_returns_job_instead_of_network_error(

--- a/crates/apps/rugix-admin/frontend/tests/fixtures/fake_rugix_ctrl.py
+++ b/crates/apps/rugix-admin/frontend/tests/fixtures/fake_rugix_ctrl.py
@@ -108,6 +108,13 @@ def main() -> int:
         write_json(app_info(args[2]))
         return 0
 
+    if is_url_update_command(args):
+        print("fake system update download started")
+        write_json({"event": "UpdateProgress", "progress": 12.4})
+        print("fake system update install running")
+        write_json({"event": "UpdateProgress", "progress": 100.0})
+        return 0
+
     if is_upload_command(args):
         early_exit = state / "early-exit-next-upload"
         if early_exit.exists():
@@ -176,6 +183,10 @@ def app_info(name: str) -> dict:
         "state": {"state": "active", "generation": active_generation},
         "generations": generations,
     }
+
+
+def is_url_update_command(args: list[str]) -> bool:
+    return bool(args and args[0:2] == ["update", "install"] and args[-1].startswith(("http://", "https://")))
 
 
 def is_upload_command(args: list[str]) -> bool:

--- a/crates/apps/rugix-admin/schemas/events.sidex
+++ b/crates/apps/rugix-admin/schemas/events.sidex
@@ -9,6 +9,8 @@ variant AdminEvent {
     JobOutput: JobOutputEvent,
     /// The upload phase changed.
     UploadProgress: UploadProgressEvent,
+    /// The installation phase changed.
+    InstallProgress: InstallProgressEvent,
 }
 
 /// Event emitted when a job changes.
@@ -33,4 +35,12 @@ record UploadProgressEvent {
     job_id: string,
     /// Number of uploaded bytes written to the child process.
     bytes: u64,
+}
+
+/// Event emitted while a system update is being installed.
+record InstallProgressEvent {
+    /// Stable job id.
+    job_id: string,
+    /// Installation progress percentage.
+    progress: f64,
 }

--- a/crates/apps/rugix-admin/src/ctrl.rs
+++ b/crates/apps/rugix-admin/src/ctrl.rs
@@ -390,6 +390,12 @@ where
         match lines.next_line().await {
             Ok(Some(line)) => {
                 debug!(%job_id, %stream, line = %line, "rugix-ctrl output");
+                if stream == "stdout" {
+                    if let Some(progress) = parse_update_progress(&line) {
+                        jobs.emit_install_progress(&job_id, progress).await;
+                        continue;
+                    }
+                }
                 jobs.emit_output(&job_id, stream, line).await;
             }
             Ok(None) => break,
@@ -399,6 +405,15 @@ where
             }
         }
     }
+}
+
+fn parse_update_progress(line: &str) -> Option<f64> {
+    let value: Value = serde_json::from_str(line).ok()?;
+    if value.get("event").and_then(Value::as_str) != Some("UpdateProgress") {
+        return None;
+    }
+    let progress = value.get("progress").and_then(Value::as_f64)?;
+    progress.is_finite().then(|| progress.clamp(0.0, 100.0))
 }
 
 async fn drain_upload_after_failure(job_id: &str, multipart: &mut Multipart) {

--- a/crates/apps/rugix-admin/src/handlers.rs
+++ b/crates/apps/rugix-admin/src/handlers.rs
@@ -65,18 +65,7 @@ pub(crate) async fn upload_system_update(
     Query(query): Query<SystemInstallQuery>,
     multipart: Multipart,
 ) -> ApiResult<Json<api::JobResponse>> {
-    let mut args = vec!["update".to_owned(), "install".to_owned()];
-    apply_install_options(&mut args, &query.common());
-    if let Some(reboot) = query.reboot {
-        args.extend(["--reboot".to_owned(), reboot]);
-    }
-    if let Some(boot_group) = query.boot_group {
-        args.extend(["--boot-group".to_owned(), boot_group]);
-    }
-    if query.keep_overlay.unwrap_or(false) {
-        args.push("--keep-overlay".to_owned());
-    }
-    args.push("-".to_owned());
+    let args = system_update_args(query, "-".to_owned());
 
     state
         .jobs
@@ -89,6 +78,34 @@ pub(crate) async fn upload_system_update(
         .await?;
     stream_upload_job(state.jobs.clone(), job_id.clone(), args, multipart, "image").await;
     Ok(Json(api::JobResponse::new(state.jobs.get(&job_id).await?)))
+}
+
+pub(crate) async fn install_system_update_from_url(
+    State(state): State<ServerState>,
+    Path(job_id): Path<String>,
+    Query(query): Query<SystemInstallQuery>,
+    Json(request): Json<SystemUpdateUrlRequest>,
+) -> ApiResult<Json<api::JobResponse>> {
+    let url = request.url.trim();
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return Err(ApiError::bad_request(
+            "invalid-url",
+            "system update URL must start with http:// or https://",
+        ));
+    }
+
+    let args = system_update_args(query, url.to_owned());
+    let job = state
+        .jobs
+        .create(
+            Some(job_id.clone()),
+            "Install system update".to_owned(),
+            "system-update".to_owned(),
+            None,
+        )
+        .await?;
+    spawn_command_job(state.jobs.clone(), job_id, args);
+    Ok(Json(api::JobResponse::new(job)))
 }
 
 pub(crate) async fn system_action(
@@ -323,6 +340,12 @@ pub(crate) struct SystemInstallQuery {
     keep_overlay: Option<bool>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SystemUpdateUrlRequest {
+    url: String,
+}
+
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AppInstallQuery {
@@ -373,11 +396,28 @@ fn apply_install_options(args: &mut Vec<String>, query: &InstallQuery) {
     }
 }
 
+fn system_update_args(query: SystemInstallQuery, bundle: String) -> Vec<String> {
+    let mut args = vec!["update".to_owned(), "install".to_owned()];
+    apply_install_options(&mut args, &query.common());
+    if let Some(reboot) = query.reboot {
+        args.extend(["--reboot".to_owned(), reboot]);
+    }
+    if let Some(boot_group) = query.boot_group {
+        args.extend(["--boot-group".to_owned(), boot_group]);
+    }
+    if query.keep_overlay.unwrap_or(false) {
+        args.push("--keep-overlay".to_owned());
+    }
+    args.push(bundle);
+    args
+}
+
 fn sse_event(event: events::AdminEvent) -> Event {
     let event_name = match &event {
         events::AdminEvent::JobChanged(_) => "job-changed",
         events::AdminEvent::JobOutput(_) => "job-output",
         events::AdminEvent::UploadProgress(_) => "upload-progress",
+        events::AdminEvent::InstallProgress(_) => "install-progress",
     };
     Event::default()
         .event(event_name)

--- a/crates/apps/rugix-admin/src/jobs.rs
+++ b/crates/apps/rugix-admin/src/jobs.rs
@@ -133,6 +133,17 @@ impl JobManager {
         .await;
     }
 
+    pub(crate) async fn emit_install_progress(&self, job_id: &str, progress: f64) {
+        self.push_event(
+            job_id,
+            events::AdminEvent::InstallProgress(events::InstallProgressEvent::new(
+                job_id.to_owned(),
+                progress,
+            )),
+        )
+        .await;
+    }
+
     async fn update_job(&self, job_id: &str, update: impl FnOnce(&mut jobs::Job)) {
         let event = {
             let mut inner = self.inner.write().await;

--- a/crates/apps/rugix-admin/src/main.rs
+++ b/crates/apps/rugix-admin/src/main.rs
@@ -70,6 +70,10 @@ async fn main() {
             "/api/system/update/:job_id",
             post(handlers::upload_system_update),
         )
+        .route(
+            "/api/system/update/:job_id/url",
+            post(handlers::install_system_update_from_url),
+        )
         .route("/api/system/actions/:action", post(handlers::system_action))
         .route("/api/apps", get(handlers::list_apps))
         .route(

--- a/crates/apps/rugix-ctrl/src/cli.rs
+++ b/crates/apps/rugix-ctrl/src/cli.rs
@@ -1569,7 +1569,8 @@ fn install_update_bundle<R: BundleSource>(
             .load_hooks("update-install")
             .whatever("unable to load `update-install` hooks")?;
 
-        let mut last_progress = 0.0;
+        let mut last_hook_progress = 0.0;
+        let mut last_output_progress = 0.0;
         move |source: &R| {
             let Some(bytes_total) = source.bytes_total() else {
                 return;
@@ -1583,7 +1584,7 @@ fn install_update_bundle<R: BundleSource>(
                 update_state.bytes_read = bytes_read.raw;
                 update_state.bytes_total = bytes_total.raw;
             }
-            if current_progress - last_progress > 0.9 {
+            if current_progress - last_hook_progress > 0.9 {
                 let hook_vars = vars! {
                     RUGIX_UPDATE_PROGRESS = format!("{current_progress:.2}")
                 };
@@ -1594,9 +1595,9 @@ fn install_update_bundle<R: BundleSource>(
                 ) {
                     warn!("error running 'update-install/progress' hooks: {error:?}");
                 }
-                last_progress = current_progress;
+                last_hook_progress = current_progress;
             }
-            if current_progress - last_progress > 0.4 && rugix_cli::stdout_is_piped() {
+            if current_progress - last_output_progress > 0.4 && rugix_cli::stdout_is_piped() {
                 let mut stdout = std::io::stdout();
                 stdout
                     .write_all(
@@ -1607,6 +1608,7 @@ fn install_update_bundle<R: BundleSource>(
                     )
                     .ok();
                 stdout.write_all(b"\n").ok();
+                last_output_progress = current_progress;
             }
         }
     };


### PR DESCRIPTION
## Summary

This PR adds URL-based system update installs to Rugix Admin, including progress display during installation.

## Core Features

- API endpoint for installing a system update from a URL
- Frontend URL install flow in the system update panel
- Job creation and tracking for URL-based installs
- Streaming `rugix-ctrl` output into job logs
- Shared install option handling for uploaded bundles and URL installs

## API
Http Request
```http
POST /api/system/update/:job_id/url
Content-Type: application/json
```
Request Body
```json
{
  "url": "https://example.com/update.rugixb"
}
```

## Web UI
<img width="1032" height="319" alt="grafik" src="https://github.com/user-attachments/assets/290b5568-1c63-4998-aa9b-17e8abac013c" />
<img width="1478" height="162" alt="grafik" src="https://github.com/user-attachments/assets/d76bee1b-a61d-42dc-9b5e-4a8897cf16a1" />
